### PR TITLE
Fix: Configure Playwright for CI and update tests

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -2,9 +2,9 @@ name: Playwright Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   playwright_tests:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: 'http://localhost:4321',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -60,9 +60,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'npm run build && npm run preview',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -4,7 +4,7 @@ test('homepage has correct title and heading', async ({ page }) => {
   // Navigate to the homepage.
   // The baseURL is not set in playwright.config.ts, so we use a relative path.
   // Assuming the dev server runs on http://localhost:4321 (default for Astro dev)
-  await page.goto('http://localhost:4321/');
+  await page.goto('/');
 
   // Check if the page title is correct.
   // We need to find the correct title from src/components/BaseHead.astro or src/consts.ts

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -7,7 +7,7 @@ test('navigation from homepage to about page', async ({ page }) => {
 
   // Find the "About" link in the header and click it.
   // The link has text "About" and href="/about".
-  const aboutLink = page.locator('header nav >> text=About[href="/about"]');
+  const aboutLink = page.locator('#nav-menu a[href="/about"]');
   await aboutLink.click();
 
   // Check if the URL is now /about.

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test('navigation from homepage to about page', async ({ page }) => {
   // Navigate to the homepage.
   // Assuming the dev server runs on http://localhost:4321 (default for Astro dev)
-  await page.goto('http://localhost:4321/');
+  await page.goto('/');
 
   // Find the "About" link in the header and click it.
   // The link has text "About" and href="/about".


### PR DESCRIPTION
This commit addresses issues causing Playwright tests to fail in CI.

Changes include:
- Configured the `webServer` option in `playwright.config.ts` to build and preview the Astro site (`npm run build && npm run preview`) on `http://localhost:4321`.
- Set the `baseURL` in `playwright.config.ts` to `http://localhost:4321`.
- Updated test files (`tests/homepage.spec.ts` and `tests/navigation.spec.ts`) to use relative paths for `page.goto()`, making them compatible with the `baseURL`.
- Verified that the homepage title assertion remains correct.

These changes ensure that Playwright can correctly start the application and navigate to pages during CI runs.